### PR TITLE
do not loop endlessly if http connection remains open

### DIFF
--- a/esphome/components/online_image/online_image.cpp
+++ b/esphome/components/online_image/online_image.cpp
@@ -249,6 +249,7 @@ void OnlineImage::update() {
 
   std::unique_ptr<ImageDecoder> decoder;
 
+  http.setFollowRedirects(HTTPC_FORCE_FOLLOW_REDIRECTS);
   int begin_status = http.begin(url_);
   if (!begin_status) {
     ESP_LOGE(TAG, "Could not download image from %s. Connection failed: %i", url_, begin_status);

--- a/esphome/components/online_image/png_image.cpp
+++ b/esphome/components/online_image/png_image.cpp
@@ -53,7 +53,12 @@ size_t HOT PngDecoder::decode(HTTPClient &http, WiFiClient *stream, std::vector<
   int remain = 0;
   int total = 0;
   uint8_t *buffer = buf.data();
-  while (http.connected()) {
+
+  int file_size = http.getSize();
+
+  // keep downloading as long as client is connected and the whole file has not been fully downloaded
+  // HTTPClient returns -1 if server does not provide Content-Length header
+  while (http.connected() && (total < file_size || file_size == -1)) {
     App.feed_wdt();
     size_t size = stream->available();
     if (!size || size < 1024 && download_size_ - total > size) {


### PR DESCRIPTION
Porting the original patch from https://github.com/esphome/esphome/pull/3255 to avoid an infinite loop until the server closes the HTTP connection