### PR TITLE
Update online_image.h

### DIFF
--- a/esphome/components/online_image/online_image.h
+++ b/esphome/components/online_image/online_image.h
@@ -76,7 +76,7 @@ class OnlineImage : public PollingComponent, public image::Image {
 
   int get_position_(int x, int y) const { return ((x + y * buffer_width_) * image::image_type_to_bpp(type_)) / 8; }
 
-  ESPHOME_ALWAYS_INLINE bool auto_resize_() const { return fixed_width_ == 0 || fixed_height_ == 0; }
+  ALWAYS_INLINE  bool auto_resize_() const { return fixed_width_ == 0 || fixed_height_ == 0; }
 
   bool resize_(int width, int height);
   void draw_pixel_(int x, int y, Color color);


### PR DESCRIPTION
Fix of a issue that ESPHome 2024.4.2 throws on compliation:

```
Compiling .pioenvs/esphome-web-74b204/src/esphome/components/online_image/png_image.cpp.o
In file included from src/esphome/components/online_image/image_decoder.cpp:4:
src/esphome/components/online_image/online_image.h:79:3: error: 'ESPHOME_ALWAYS_INLINE' does not name a type; did you mean 'ALWAYS_INLINE'?
   ESPHOME_ALWAYS_INLINE bool auto_resize_() const { return fixed_width_ == 0 || fixed_height_ == 0; }
   ^~~~~~~~~~~~~~~~~~~~~
   ALWAYS_INLINE
In file included from src/esphome/components/online_image/online_image.cpp:3:
src/esphome/components/online_image/online_image.h:79:3: error: 'ESPHOME_ALWAYS_INLINE' does not name a type; did you mean 'ALWAYS_INLINE'?
   ESPHOME_ALWAYS_INLINE bool auto_resize_() const { return fixed_width_ == 0 || fixed_height_ == 0; }
   ^~~~~~~~~~~~~~~~~~~~~
   ALWAYS_INLINE
src/esphome/components/online_image/online_image.cpp: In member function 'bool esphome::online_image::OnlineImage::resize_(int, int)':
src/esphome/components/online_image/online_image.cpp:143:7: error: 'auto_resize_' was not declared in this scope
   if (auto_resize_()) {
       ^~~~~~~~~~~~
src/esphome/components/online_image/online_image.cpp:143:7: note: suggested alternative: 'resize_'
   if (auto_resize_()) {
       ^~~~~~~~~~~~
       resize_
*** [.pioenvs/esphome-web-74b204/src/esphome/components/online_image/image_decoder.cpp.o] Error 1
```

There was some shuffle around names of macros in esphome that includes renaming ALWAYS_INLINE to ESPHOME_ALWAYS_INLINE. In this case it does not worked for some reason.

This PR is mainly to bring focus to a problem rather than tested solution - it worked for mine ESP32-WROOM LilyGo T5 4.7" board. 

BTW - online_image is a great addition to esphome :)